### PR TITLE
Prevent PowerShell console to close after the script finishes from running

### DIFF
--- a/src/cis-vsphere.ps1
+++ b/src/cis-vsphere.ps1
@@ -144,3 +144,5 @@ Ensure-VirtualDiskWipingIsDisabled
 Ensure-TheNumberOfVMLogFilesIsConfiguredProperly
 Ensure-HostInformationIsNotSentToGuests
 Ensure-VMLogFileSizeIsLimited
+
+Read-Host -Prompt "Press Enter to exit"


### PR DESCRIPTION
I noticed that after executing the script, it immediately gets closed after it finishes from running.
The code that I added prevents this issue from happening.